### PR TITLE
CI: set package version for jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,8 +234,8 @@ jobs:
           ./build-release-nupkg.sh
       - uses: actions/upload-artifact@v3
         with:
-          name: org.ldk.nupkg
-          path: c_sharp/org.ldk.nupkg
+          name: LdkSharp.nupkg
+          path: c_sharp/LdkSharp.nupkg
 
   java_bindings:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: Continuous Integration Checks
 
 on: [push, pull_request]
 
+env:
+  NUGET_PACKAGE_VERSION: 0.0.0.5
+
 jobs:
   wasm_bindings:
     runs-on: ubuntu-latest
@@ -172,6 +175,8 @@ jobs:
     container: fedora:39
     strategy:
       fail-fast: false
+    env:
+      DOTNET_NOLOGO: true
     steps:
       - name: Install required dependencies
         run: |
@@ -210,23 +215,22 @@ jobs:
           ./genbindings.sh ../rust-lightning true
       - name: Remove checked-in source to ensure its correctly checked-in
         run: rm c_sharp/src/org/ldk/enums/*.cs c_sharp/src/org/ldk/impl/*.cs c_sharp/src/org/ldk/structs/*.cs
+      - name: Set package version
+        run: |
+          echo "LDK_GARBAGECOLLECTED_GIT_OVERRIDE=v$(dotnet fsi nugetPreRelease.fsx $NUGET_PACKAGE_VERSION)" >> "$GITHUB_ENV"
       - name: Build Windows C# Bindings
         run: |
-          export LDK_GARBAGECOLLECTED_GIT_OVERRIDE="$(git describe --tag HEAD)"
           LDK_TARGET=x86_64-pc-windows-gnu LDK_TARGET_CPU=sandybridge ./genbindings.sh ./ldk-c-bindings/ c_sharp false false
       - name: Build Linux C# Bindings
         run: |
-          export LDK_GARBAGECOLLECTED_GIT_OVERRIDE="$(git describe --tag HEAD)"
           ./genbindings.sh ./ldk-c-bindings/ c_sharp false false
       - name: Build macOS x86-64 C# Bindings
         run: |
           export MACOS_SDK="$PWD/Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers"
-          export LDK_GARBAGECOLLECTED_GIT_OVERRIDE="$(git describe --tag HEAD)"
           CC=clang LDK_TARGET=x86_64-apple-darwin LDK_TARGET_CPU=sandybridge ./genbindings.sh ./ldk-c-bindings/ c_sharp false false
       - name: Build macOS aarch64 C# Bindings
         run: |
           export MACOS_SDK="$PWD/Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers"
-          export LDK_GARBAGECOLLECTED_GIT_OVERRIDE="$(git describe --tag HEAD)"
           CC=clang LDK_TARGET=aarch64-apple-darwin LDK_TARGET_CPU=apple-a14 ./genbindings.sh ./ldk-c-bindings/ c_sharp false false
       - name: Build Release NUPKG
         run: |
@@ -236,6 +240,11 @@ jobs:
         with:
           name: LdkSharp.nupkg
           path: c_sharp/LdkSharp.nupkg
+      - name: Publish nuget package on nuget.org
+        run: |
+          if [ ${{ secrets.NUGET_API_KEY }} ]; then
+            dotnet nuget push c_sharp/LdkSharp.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+          fi
 
   java_bindings:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,9 @@ jobs:
           for i in 1 2 3 4 5; do
             ./genbindings.sh ../rust-lightning false && break
           done
+      - name: Set package version
+        run: |
+          echo "LDK_GARBAGECOLLECTED_GIT_OVERRIDE=v$NUGET_PACKAGE_VERSION" >> "$GITHUB_ENV"          
       - name: Build and Test TS Debug Bindings for Node
         run: |
           # We need FinalizationRegistry and top-level await support, which requires node 14.6/8,
@@ -159,6 +162,9 @@ jobs:
           for i in 1 2 3 4 5; do
             ./genbindings.sh ../rust-lightning true && break
           done
+      - name: Set package version
+        run: |
+          echo "LDK_GARBAGECOLLECTED_GIT_OVERRIDE=v$NUGET_PACKAGE_VERSION" >> "$GITHUB_ENV"
       - name: Build and Test C# Debug Bindings
         run: |
           ./genbindings.sh ./ldk-c-bindings/ c_sharp true true
@@ -297,6 +303,9 @@ jobs:
           for i in 1 2 3 4 5; do
             ./genbindings.sh ../rust-lightning true && break
           done
+      - name: Set package version
+        run: |
+          echo "LDK_GARBAGECOLLECTED_GIT_OVERRIDE=v$NUGET_PACKAGE_VERSION" >> "$GITHUB_ENV"
       - name: Build Java Debug Bindings
         run: ./genbindings.sh ./ldk-c-bindings/ "-I/usr/lib/jvm/java-17-openjdk-amd64/include/ -I/usr/lib/jvm/java-17-openjdk-amd64/include/linux/" true false
       - name: Run Java Tests against Debug Bindings

--- a/c_sharp/build-release-nupkg.sh
+++ b/c_sharp/build-release-nupkg.sh
@@ -11,4 +11,4 @@ ls packaging_artifacts/lib/net6.0/csharpldk.dll
 
 cd packaging_artifacts
 find . | xargs -L1 touch -d "2021-01-01 00:00 UTC" 
-zip -Xvu ../org.ldk.nupkg * */* */*/* */*/*/* */*/*/*/*
+zip -Xvu ../LdkSharp.nupkg * */* */*/* */*/*/* */*/*/*/*

--- a/c_sharp/packaging_artifacts/LdkSharp.nuspec
+++ b/c_sharp/packaging_artifacts/LdkSharp.nuspec
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
-    <id>org.ldk</id>
+    <id>LdkSharp</id>
     <version>Set in genbindings.sh automagically</version>
     <authors>LDK</authors>
     <license type="file">LICENSE.md</license>

--- a/c_sharp/packaging_artifacts/_rels/.rels
+++ b/c_sharp/packaging_artifacts/_rels/.rels
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
-  <Relationship Type="http://schemas.microsoft.com/packaging/2010/07/manifest" Target="/org.ldk.nuspec" Id="spec" />
+  <Relationship Type="http://schemas.microsoft.com/packaging/2010/07/manifest" Target="/LdkSharp.nuspec" Id="spec" />
   <Relationship Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="/package/services/metadata/core-properties/ldk.psmdcp" Id="Properties" />
 </Relationships>

--- a/c_sharp/packaging_artifacts/package/services/metadata/core-properties/ldk.psmdcp
+++ b/c_sharp/packaging_artifacts/package/services/metadata/core-properties/ldk.psmdcp
@@ -2,7 +2,7 @@
 <coreProperties xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.openxmlformats.org/package/2006/metadata/core-properties">
   <dc:creator>LDK</dc:creator>
   <dc:description>LDK C# Bindings</dc:description>
-  <dc:identifier>org.ldk</dc:identifier>
+  <dc:identifier>LdkSharp</dc:identifier>
   <version>Set in genbindings.sh automagically</version>
   <keywords>bitcoin lightning ldk sdk non-custodial</keywords>
   <lastModifiedBy>hand</lastModifiedBy>

--- a/genbindings.sh
+++ b/genbindings.sh
@@ -133,11 +133,11 @@ if [ "$2" = "c_sharp" ]; then
 	cat c_sharp/bindings.c.body >> c_sharp/bindings.c
 
 	if is_gnu_sed; then
-		sed -i "s/<version>.*<\/version>/<version>${LDK_GARBAGECOLLECTED_GIT_OVERRIDE:1:100}<\/version>/g" c_sharp/packaging_artifacts/org.ldk.nuspec
+		sed -i "s/<version>.*<\/version>/<version>${LDK_GARBAGECOLLECTED_GIT_OVERRIDE:1:100}<\/version>/g" c_sharp/packaging_artifacts/LdkSharp.nuspec
 		sed -i "s/<version>.*<\/version>/<version>${LDK_GARBAGECOLLECTED_GIT_OVERRIDE:1:100}<\/version>/g" c_sharp/packaging_artifacts/package/services/metadata/core-properties/ldk.psmdcp
 	else
 		# OSX sed is for some reason not compatible with GNU sed
-		sed -i '' "s/<version>.*<\/version>/<version>${LDK_GARBAGECOLLECTED_GIT_OVERRIDE:1:100}<\/version>/g" c_sharp/packaging_artifacts/org.ldk.nuspec
+		sed -i '' "s/<version>.*<\/version>/<version>${LDK_GARBAGECOLLECTED_GIT_OVERRIDE:1:100}<\/version>/g" c_sharp/packaging_artifacts/LdkSharp.nuspec
 		sed -i '' "s/<version>.*<\/version>/<version>${LDK_GARBAGECOLLECTED_GIT_OVERRIDE:1:100}<\/version>/g" c_sharp/packaging_artifacts/package/services/metadata/core-properties/ldk.psmdcp
 	fi
 

--- a/nugetPreRelease.fsx
+++ b/nugetPreRelease.fsx
@@ -1,0 +1,6 @@
+#r "nuget: Fsdk, Version=0.6.0--date20231213-0703.git-d7a5962"
+
+let args = fsi.CommandLineArgs
+
+Fsdk.Network.GetNugetPrereleaseVersionFromBaseVersion args.[1]
+|> System.Console.WriteLine


### PR DESCRIPTION
Set package version for jobs other than c_sharp_determinism because otherwise script tries to generate version based on tag and fails. Since dotnet is not installed in those jobs, don't use nugetPreRelease.fsx to get version, just use
NUGET_PACKAGE_VERSION.